### PR TITLE
solve reported issue #155 - fixed read lengths

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -1006,7 +1006,6 @@ def simulation_aligned_transcriptome(model_ir, out_reads, out_error, kmer_bias, 
             if "chr" in item:
                 flag_chrom = True
                 break
-    sampled_2d_lengths = get_length_kde(kde_aligned_2d, num_simulate, False, False)
 
     remainder_l = get_length_kde(kde_ht, num_simulate, True)
     head_vs_ht_ratio_temp = get_length_kde(kde_ht_ratio, num_simulate)
@@ -1016,6 +1015,7 @@ def simulation_aligned_transcriptome(model_ir, out_reads, out_error, kmer_bias, 
     remaining_reads = 0
     while remaining_reads < num_simulate:
         while True:
+            sampled_2d_lengths = get_length_kde(kde_aligned_2d, num_simulate, False, False)
             ref_trx, ref_trx_len = select_ref_transcript(ecdf_dict_ref_exp)
             if polya and ref_trx in trx_with_polya:
                 trx_has_polya = True


### PR DESCRIPTION
Thanks to Haoran who reported the issue with fixed transcriptome read length generated by NanoSim for single thread #155 

The reason for this issue was that the 2-dimensional Kernel Density Estimates (KDE) were generated all at once before selecting each reference transcript. Therefore, with a single thread, it would result in generating similar read lengths. Thanks to Haoran's suggestion, I adjusted the code so that it generate the 2D KDE everytime we select a reference transcript to simulate reads from, ensuring that there will be no similar read length given a specific reference transcript. 

Please note that I did some analysis on different approaches to solve this issue and I believe the one suggested by Haoran (KDE generation for each reference transcript) is simple and efficient enough. 