### PR TITLE
fix read headers in metagenome simulation

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -924,7 +924,6 @@ def simulation_aligned_metagenome(min_l, max_l, median_l, sd_l, out_reads, out_e
                                  "_" + str(tail)
                     
                 read_mutated = ""
-                new_read_name = ""
                 base_quals = []
                 for seg_idx in range(num_seg):
                     # Mutate read


### PR DESCRIPTION
Hi,

When running metagenome simulations while outputting fastq files, with the most recent version of NanoSim 3.1, I found that read headers are empty (consisting only of the initial `@` but no other information). It seems like right before finalization of a read, the header is set to the empty string once again. This PR fixes this.

I have attached a directory ([test_case_nanosim.tar.gz](https://github.com/bcgsc/NanoSim/files/8871716/test_case_nanosim.tar.gz)) containing all required files for building a docker container which replicates the issue, and demonstrates the fix described in this PR, which can be built and executed by running `docker build .`.