### PR TITLE
Rbk mode

### DIFF
--- a/src/read_analysis.py
+++ b/src/read_analysis.py
@@ -253,7 +253,7 @@ def main():
                           default='')
     parser_g.add_argument('-a', '--aligner', help='The aligner to be used, minimap2 or LAST (Default = minimap2)',
                           choices=['minimap2', 'LAST'], default='minimap2')
-    parser_g.add_argument('-ga', '--g_alnm', help='Genome alignment file in SAM/BAM format (optional)', default='')
+    parser_g.add_argument('-ga', '--g_alnm', help='Genome alignment file in sam or maf format (optional)', default='')
     parser_g.add_argument('-o', '--output', help='The location and prefix of outputting profiles (Default = training)',
                           default='training')
     parser_g.add_argument('-c', '--chimeric', help='Detect chimeric and split reads (Default = False)',
@@ -270,8 +270,8 @@ def main():
                                                          'required for intron retention detection', default='')
     parser_t.add_argument('-a', '--aligner', help='The aligner to be used: minimap2 or LAST (Default = minimap2)',
                           choices=['minimap2', 'LAST'], default='minimap2')
-    parser_t.add_argument('-ga', '--g_alnm', help='Genome alignment file in SAM/BAM format (optional)', default='')
-    parser_t.add_argument('-ta', '--t_alnm', help='Transcriptome alignment file in SAM/BAM format (optional)',
+    parser_t.add_argument('-ga', '--g_alnm', help='Genome alignment file in sam or maf format (optional)', default='')
+    parser_t.add_argument('-ta', '--t_alnm', help='Transcriptome alignment file in sam or maf format (optional)',
                           default='')
     parser_t.add_argument('-o', '--output', help='The location and prefix of outputting profiles (Default = training)',
                           default='training')
@@ -339,8 +339,8 @@ def main():
     parser_ir.add_argument('-a', '--aligner', help='The aligner to be used: minimap2 or LAST (Default = minimap2)',
                            choices=['minimap2', 'LAST'], default='minimap2')
     parser_ir.add_argument('-o', '--output', help='The output name and location', required=False, default='ir_info')
-    parser_ir.add_argument('-ga', '--g_alnm', help='Genome alignment file in SAM/BAM format (optional)', default='')
-    parser_ir.add_argument('-ta', '--t_alnm', help='Transcriptome alignment file in SAM/BAM format (optional)',
+    parser_ir.add_argument('-ga', '--g_alnm', help='Genome alignment file in sam or maf format (optional)', default='')
+    parser_ir.add_argument('-ta', '--t_alnm', help='Transcriptome alignment file in sam or maf format (optional)',
                            default='')
     parser_ir.add_argument('-t', '--num_threads', help='Number of threads for alignment (Default = 1)', default='1')
 

--- a/src/read_analysis.py
+++ b/src/read_analysis.py
@@ -253,7 +253,7 @@ def main():
                           default='')
     parser_g.add_argument('-a', '--aligner', help='The aligner to be used, minimap2 or LAST (Default = minimap2)',
                           choices=['minimap2', 'LAST'], default='minimap2')
-    parser_g.add_argument('-ga', '--g_alnm', help='Genome alignment file in sam or maf format (optional)', default='')
+    parser_g.add_argument('-ga', '--g_alnm', help='Genome alignment file in SAM/BAM format (optional)', default='')
     parser_g.add_argument('-o', '--output', help='The location and prefix of outputting profiles (Default = training)',
                           default='training')
     parser_g.add_argument('-c', '--chimeric', help='Detect chimeric and split reads (Default = False)',
@@ -270,8 +270,8 @@ def main():
                                                          'required for intron retention detection', default='')
     parser_t.add_argument('-a', '--aligner', help='The aligner to be used: minimap2 or LAST (Default = minimap2)',
                           choices=['minimap2', 'LAST'], default='minimap2')
-    parser_t.add_argument('-ga', '--g_alnm', help='Genome alignment file in sam or maf format (optional)', default='')
-    parser_t.add_argument('-ta', '--t_alnm', help='Transcriptome alignment file in sam or maf format (optional)',
+    parser_t.add_argument('-ga', '--g_alnm', help='Genome alignment file in SAM/BAM format (optional)', default='')
+    parser_t.add_argument('-ta', '--t_alnm', help='Transcriptome alignment file in SAM/BAM format (optional)',
                           default='')
     parser_t.add_argument('-o', '--output', help='The location and prefix of outputting profiles (Default = training)',
                           default='training')
@@ -339,8 +339,8 @@ def main():
     parser_ir.add_argument('-a', '--aligner', help='The aligner to be used: minimap2 or LAST (Default = minimap2)',
                            choices=['minimap2', 'LAST'], default='minimap2')
     parser_ir.add_argument('-o', '--output', help='The output name and location', required=False, default='ir_info')
-    parser_ir.add_argument('-ga', '--g_alnm', help='Genome alignment file in sam or maf format (optional)', default='')
-    parser_ir.add_argument('-ta', '--t_alnm', help='Transcriptome alignment file in sam or maf format (optional)',
+    parser_ir.add_argument('-ga', '--g_alnm', help='Genome alignment file in SAM/BAM format (optional)', default='')
+    parser_ir.add_argument('-ta', '--t_alnm', help='Transcriptome alignment file in SAM/BAM format (optional)',
                            default='')
     parser_ir.add_argument('-t', '--num_threads', help='Number of threads for alignment (Default = 1)', default='1')
 


### PR DESCRIPTION
- Added a new mode "rbk" (rapid barcode kit) to replicate the read distribution seen in Nanopore amplicon rbk data, where forward reads are enriched at the amplicon 3' end and reverse reads are enriched at the 5' end.
- Stopped simulating unaligned flanking head and tail regions in all modes, with option to turn it back on if required.
- Fixed an issue where when a minimum read length parameter was set in 'genome' or 'rbk' mode, if a generated read was too short it was repeatedly reset and mutated until it reached the length threshold. This resulted in an unrealistically high number of reads just longer than the minimum threshold. Now the read is just discarded and a new read length randomly sampled.
- Added a new pre-trained error model: amplicon-rbk