### PR TITLE
Fixes for transcriptome and metagenome modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,8 @@ If you are interested in simulating ONT metagenome reads, you need to run the ch
 __metagenome mode usage:__
 ```
 usage: read_analysis.py metagenome [-h] -i READ -gl GENOME_LIST [-ga G_ALNM]
-                                   [-o OUTPUT] [-c] [-q] [-hp]
-                                   [--min_homopolymer_len MIN_HOMOPOLYMER_LEN]
-                                   [--fastq] [--no_model_fit] [-t NUM_THREADS]
+                                   [-o OUTPUT] [-c] [-q] [--fastq]
+                                   [--no_model_fit] [-t NUM_THREADS]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -249,10 +248,6 @@ optional arguments:
   -q, --quantification  Perform abundance quantification and compute the
                         deviation between calculated abundance and expected
                         values (Default = False)
-  -hp, --homopolymer    Analyze homopolymer lengths (Default = False)
-  --min_homopolymer_len MIN_HOMOPOLYMER_LEN
-                        Minimum length of homopolymers to analyze (Default = 5
-                        bp)
   --fastq               Analyze base qualities (Default = False)
   --no_model_fit        Disable model fitting step
   -t NUM_THREADS, --num_threads NUM_THREADS
@@ -497,7 +492,7 @@ usage: simulator.py metagenome [-h] -gl GENOME_LIST -a ABUN
                                [-dl DNA_TYPE_LIST] [-c MODEL_PREFIX]
                                [-o OUTPUT] [-max MAX_LEN] [-min MIN_LEN]
                                [-med MEDIAN_LEN] [-sd SD_LEN] [--seed SEED]
-                               [-hp] [-k KMERBIAS] [-s STRANDNESS] [--perfect]
+                               [-s STRANDNESS] [--perfect]
                                [--abun_var ABUN_VAR [ABUN_VAR ...]] [--fastq]
                                [--chimeric] [-t NUM_THREADS]
 
@@ -528,17 +523,13 @@ optional arguments:
                         The minimum length for simulated reads (Default = 50)
   -med MEDIAN_LEN, --median_len MEDIAN_LEN
                         The median read length (Default = None), Note: this
-                        simulationis not compatible with chimeric reads
+                        simulation is not compatible with chimeric reads
                         simulation
   -sd SD_LEN, --sd_len SD_LEN
                         The standard deviation of read length in log scale
                         (Default = None), Note: this simulation is not
                         compatible with chimeric reads simulation
   --seed SEED           Manually seeds the pseudo-random number generator
-  -hp, --homopolymer    Simulate homopolymer lengths (Default = False)
-  -k KMERBIAS, --KmerBias KMERBIAS
-                        Minimum homopolymer length to simulate homopolymer
-                        contraction andexpansion events in, a typical k is 6
   -s STRANDNESS, --strandness STRANDNESS
                         Percentage of antisense sequences. Overrides the value
                         profiled in characterization stage. Should be between

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ usage: read_analysis.py transcriptome [-h] -i READ -rg REF_G -rt REF_T
                                       [-annot ANNOTATION] [-a {minimap2,LAST}]
                                       [-ga G_ALNM] [-ta T_ALNM] [-o OUTPUT]
                                       [--no_model_fit] [--no_intron_retention]
-                                      [-t NUM_THREADS] [-c] [-q] [-n] [-hp]
+                                      [-t NUM_THREADS] [-q] [-n] [-hp]
                                       [--min_homopolymer_len MIN_HOMOPOLYMER_LEN]
                                       [--fastq]
 
@@ -209,7 +209,6 @@ optional arguments:
   -t NUM_THREADS, --num_threads NUM_THREADS
                         Number of threads for alignment and model fitting
                         (Default = 1)
-  -c, --chimeric        Detect chimeric and split reads (Default = False)
   -q, --quantification  Perform abundance quantification (Default = False)
   -n, --normalize       Normalize by transcript length
   -hp, --homopolymer    Analyze homopolymer lengths (Default = False

--- a/src/get_primary_sam.py
+++ b/src/get_primary_sam.py
@@ -456,7 +456,7 @@ def primary_and_unaligned_chimeric(sam_alnm_file, prefix, metagenome_list=None, 
 
     strandness = float(pos_strand) / num_aligned
     if q_mode:
-        return [], strandness
+        return [], strandness, unaligned_bq
 
     out_sam_file.close()
     unaligned_len = numpy.array(unaligned_len)

--- a/src/model_base_qualities.py
+++ b/src/model_base_qualities.py
@@ -63,6 +63,9 @@ def analyze_aligned_base_qualities(primary_alnm_file):
 
     cs_dict = {":": "match", "+": "ins", "*": "mis"}
     for alnm in alignments:
+        if alnm.is_secondary:
+            print(f"Skipping secondary alignment: {alnm.query_name}", file=sys.stderr)
+            continue
         quals = alnm.query_alignment_qualities.tolist()
 
         read = alnm.query_alignment_sequence

--- a/src/model_homopolymer_lengths.py
+++ b/src/model_homopolymer_lengths.py
@@ -147,6 +147,10 @@ def fit_piecewise(hp_lengths_per_base):
         yy = list(np.mean(hp_read_lengths, dtype=np.float64) for hp_read_lengths in hp_lengths_per_base[base].values())
         pw_fit = piecewise_regression.Fit(xx, yy, n_breakpoints=1)  # n_breakpoints set based on previous analysis; may want to optimize this later
         pw_estimates = pw_fit.get_results()["estimates"]
+        if pw_estimates is None:
+            raise ValueError("Piecewise regression for homopolymer characterization did not converge. "
+                             "Consider using more reads, a subsample, turning off homopolymer compression, "
+                             "or using a pre-trained model.")
 
         if header == "":
             header = "\t".join(list(pw_estimates.keys()))

--- a/src/read_analysis.py
+++ b/src/read_analysis.py
@@ -304,7 +304,7 @@ def main():
                           default=True)
     parser_t.add_argument('-t', '--num_threads', help='Number of threads for alignment and model fitting (Default = 1)',
                           default='1')
-    parser_t.add_argument('-c', '--chimeric', help='Detect chimeric and split reads (Default = False)',
+    parser_t.add_argument('-c', '--chimeric', help=argparse.SUPPRESS,
                           action='store_true', default=False)
     parser_t.add_argument('-q', '--quantification', help='Perform abundance quantification (Default = False)',
                           action='store_true', default=False)
@@ -776,7 +776,6 @@ def main():
         print("num_threads", num_threads)
         print("model_fit", model_fit)
         print("intron_retention", ir)
-        print("chimeric", chimeric)
         print("homopolymer", homopolymer)
         if homopolymer:
             print("min_homopolymer_len", min_hp_len)

--- a/src/read_analysis.py
+++ b/src/read_analysis.py
@@ -619,6 +619,7 @@ def main():
         homopolymer = args.homopolymer
         min_hp_len = args.min_homopolymer_len
         fastq = args.fastq
+        aligner = "minimap2"
 
         # check validity of parameters
         if g_alnm != '':

--- a/src/read_analysis.py
+++ b/src/read_analysis.py
@@ -335,9 +335,9 @@ def main():
                                                          'between calculated abundance and expected values '
                                                          '(Default = False)',
                           action='store_true', default=False)
-    parser_m.add_argument('-hp', '--homopolymer', help='Analyze homopolymer lengths (Default = False)',
+    parser_m.add_argument('-hp', '--homopolymer', help=argparse.SUPPRESS,
                           action='store_true', default=False)
-    parser_m.add_argument('--min_homopolymer_len', help='Minimum length of homopolymers to analyze (Default = 5 bp)',
+    parser_m.add_argument('--min_homopolymer_len', help=argparse.SUPPRESS,
                           default='5')
     parser_m.add_argument('--fastq', help='Analyze base qualities (Default = False)', action='store_true',
                           default=False)
@@ -649,9 +649,6 @@ def main():
         print("num_threads", num_threads)
         print("model_fit", model_fit)
         print("chimeric", chimeric)
-        print("homopolymer", homopolymer)
-        if homopolymer:
-            print("min_homopolymer_len", min_hp_len)
         print("fastq", fastq)
         print("quantification", quantification)
 

--- a/src/simulator.py
+++ b/src/simulator.py
@@ -2100,17 +2100,16 @@ def main():
     parser_mg.add_argument('-min', '--min_len', help='The minimum length for simulated reads (Default = 50)',
                            type=int, default=50)
     parser_mg.add_argument('-med', '--median_len', help='The median read length (Default = None), Note: this simulation'
-                                                        'is not compatible with chimeric reads simulation',
+                                                        ' is not compatible with chimeric reads simulation',
                            type=int, default=None)
     parser_mg.add_argument('-sd', '--sd_len',
                            help='The standard deviation of read length in log scale (Default = None), Note: this '
                                 'simulation is not compatible with chimeric reads simulation',
                            type=float, default=None)
     parser_mg.add_argument('--seed', help='Manually seeds the pseudo-random number generator', type=int, default=None)
-    parser_mg.add_argument('-hp', '--homopolymer', help='Simulate homopolymer lengths (Default = False)',
+    parser_mg.add_argument('-hp', '--homopolymer', help=argparse.SUPPRESS,
                           action='store_true', default=False)
-    parser_mg.add_argument('-k', '--KmerBias', help='Minimum homopolymer length to simulate homopolymer contraction and'
-                                                    'expansion events in, a typical k is 6',
+    parser_mg.add_argument('-k', '--KmerBias', help=argparse.SUPPRESS,
                           type=int, default=None)
     parser_mg.add_argument('-s', '--strandness', help='Percentage of antisense sequences. Overrides the value profiled '
                                                       'in characterization stage. Should be between 0 and 1',
@@ -2367,9 +2366,6 @@ def main():
         print("model_prefix", model_prefix)
         print("out", out)
         print("perfect", perfect)
-        print("homopolymer", homopolymer)
-        if homopolymer:
-            print("kmer_bias", kmer_bias)
         print("strandness", strandness)
         print("sd_len", sd_len)
         print("median_len", median_len)


### PR DESCRIPTION
* Fix missing `aligner` variable in metagenome mode
* Fix return value when `q_mode` is True for function `primary_and_unaligned_chimeric` in `get_primary_sam.py`
* Check for and skip secondary alignments in base quality characterization
* If the homopolymer length modelling doesn't converge, detect this and raise a more informative error
* Remove `--chimeric` from transcriptome characterization to keep consistency with simulation options
* Remove homopolymer characterization/simulation from metagenome mode
  * In many tests, there wasn't enough data for the model to converge, leading to errors
  * The options are still available for advanced users, just will not be advertised in the help page