### PR TITLE
Fix for abundance deviation in metagenome mode

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -1679,16 +1679,25 @@ def extract_read(dna_type, length, s=None):
             
             # find all chromosomes that are longer
             longer_chroms = list()
+            longer_chroms_target = list()
             for tmp_s in seq_len:
                 tmp_dict = seq_len[tmp_s]
                 for tmp_key in tmp_dict:
                     if length < tmp_dict[tmp_key]:
-                        longer_chroms.append((tmp_s, tmp_key))
+                        if tmp_s == s:
+                            longer_chroms_target.append((tmp_s, tmp_key))
+                        else:
+                            longer_chroms.append((tmp_s, tmp_key))
             
-            assert len(longer_chroms) > 0 # otherwise there is a problem
-            
+            assert len(longer_chroms) > 0 or len(longer_chroms_target) > 0 # otherwise there is a problem
             # select a random chromosome from this list
-            s, key = random.choice(longer_chroms)
+            if longer_chroms_target:
+                s, key = random.choice(longer_chroms_target)
+            else:
+                s, key = random.choice(longer_chroms)
+                print("Warning: chosen species/strain is shorter than the simulated read length, randomly selected another species/strain. "
+                      "It is recommended to run read_analysis.py quantify after simulation to check abundances in simulated reads.",
+                      file = sys.stderr)
             key_seq_len = seq_len[s][key]
         
         if dict_dna_type[s][key] == "circular":


### PR DESCRIPTION
* If simulated read longer than selected chromosome, select from same species preferentially
* Previous behaviour randomly selected a different sequence from the full pool of species
* In the example of the Zymo mock model, this meant that _S. aureus_ reads ended up under-represented, while _Cryptococcus_ was over-represented
  * This was because the _S. aureus_ reference contained 4 sequences - the main circular genome and 3 short plasmids
  * When a sequence from _S. aureus_ was randomly selected, frequently the plasmids were chosen, which were shorter than the requested read length
  * Because there are more _Cryptococcus_ sequences in the reference compared with the number of sequences in other references, randomly choosing a replacement sequence from the entire pool of species/sequences meant that _Cryptococcus_ was chosen more frequently
* To retain the requested abundances as much as possible, preferentially choose the 'alternative' sequence from the same species
  * This is consistent with the version used in the meta-NanoSim paper 
* As a fall-back, if there are no appropriate sequences in the species' reference, choose another species
  * If this is required, a warning will be printed, advising the user to check the abundances after simulation finishes