### PR TITLE
Added coverage option for genomic and transcriptomic simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,9 @@ optional arguments:
                         (Default = simulated)
   -n NUMBER, --number NUMBER
                         Number of reads to be simulated (Default = 20000)
+  -x COVERAGE, --coverage COVERAGE
+                        Coverage of the simulated reads, Note: Coverage will 
+                        override the number of reads
   -max MAX_LEN, --max_len MAX_LEN
                         The maximum length for simulated reads (Default =
                         Infinity)
@@ -441,6 +444,9 @@ optional arguments:
                         (Default = simulated)
   -n NUMBER, --number NUMBER
                         Number of reads to be simulated (Default = 20000)
+  -x COVERAGE, --coverage COVERAGE
+                        Coverage of the simulated reads, Note: Coverage will 
+                        override the number of reads
   -max MAX_LEN, --max_len MAX_LEN
                         The maximum length for simulated unaligned reads. Note
                         that this is not used for simulating aligned reads.


### PR DESCRIPTION
Here, I added the coverage to read length calculation for genome and transcriptome mode of NanoSim. For the genome mode, it calculates the number of reads for the specified coverage based on the reference genome, while it uses the reference transciptome for the transcriptome mode of the simulator. I wanted to explain the changes in the following line:

* -x or --coverage flag is added to the simulator.py script. If the user specifies the coverage, it will override the -n (number of reads) parameter. 
* In order to estimate the average read length, I used both the aligned and unaligned read length kde function. Currently, the method samples total of 10,000,000 data points from the kernel density curve. Based on the Aligned / Unaligned ratio, I divide 10 million into respective number of samples from aligned and unaligned kde functions. Then, I basically take their mean (Monte Carlo approximation for average length) and divide the reference genome/transcriptome size by it. In order to add the coverage component, I multiply the number I obtained from the last step with the coverage requested. This way, we obtain the requested coverage based on the Lander/Waterman equation, as the data output is going to be divided by reference size without considering the alignment amount. 
* This could be extended to the metogenomic simulation if needed.